### PR TITLE
Display castle HP with health bar

### DIFF
--- a/headers/level.hpp
+++ b/headers/level.hpp
@@ -8,20 +8,24 @@
 
 namespace Level {
 
-    class Castle{
-    public:
-        Castle(sf::Vector2f cords, int hp);
+class Castle{
+public:
+    Castle(sf::Vector2f cords, int hp);
 
-        int get_health();
-        sf::Sprite get_sprite();
-        bool deal_damage(int damage);
+    int get_health();
+    sf::Sprite get_sprite();
+    sf::RectangleShape get_health_bar();
+    void update_health_bar();
+    bool deal_damage(int damage);
 
-    private:
-        int health;
-        sf::Texture texture;
-        sf::Sprite sprite;
-        sf::Vector2f cords;
-    };
+private:
+    int health;
+    int max_health;
+    sf::Texture texture;
+    sf::Sprite sprite;
+    sf::RectangleShape health_bar;
+    sf::Vector2f cords;
+};
     
     extern sf::Vector2f level1_castle_cords;
     extern std::vector<sf::Vector2f> level1_points_Bezier;

--- a/src/level.cpp
+++ b/src/level.cpp
@@ -15,13 +15,16 @@ namespace Level {
             sprite = sf::Sprite(texture);
             sprite.setOrigin(sf::Vector2f(100, 100));
             health = hp;
+            max_health = hp;
             cords = _cords;
             sprite.setPosition(_cords);
+            update_health_bar();
         }
     }
     
     bool Castle::deal_damage(int damage){
         health -= damage;
+        update_health_bar();
         return health <= 0;
     }
 
@@ -31,6 +34,22 @@ namespace Level {
     
     sf::Sprite Castle::get_sprite(){
         return sprite;
+    }
+
+    sf::RectangleShape Castle::get_health_bar(){
+        return health_bar;
+    }
+
+    void Castle::update_health_bar(){
+        if(max_health){
+            float percentage = static_cast<float>(health) / static_cast<float>(max_health);
+            float width = sprite.getGlobalBounds().width;
+            float height = 10.f;
+            health_bar.setSize(sf::Vector2f(width * percentage, height));
+            health_bar.setFillColor(percentage < 0.3f ? sf::Color::Red : sf::Color::Green);
+            health_bar.setOrigin(width / 2.f, height / 2.f);
+            health_bar.setPosition(cords.x, cords.y - sprite.getGlobalBounds().height / 2.f - 15.f);
+        }
     }
 
     sf::Vector2f level1_castle_cords = sf::Vector2f(860, 910);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -200,14 +200,17 @@ int main()
             for (auto* e : enemies) { window.draw(e->get_sprite()); window.draw(e->get_health_bar()); }
             for (auto* t : towers) window.draw(t->get_sprite());
             window.draw(level1.castle.get_sprite());
+            window.draw(level1.castle.get_health_bar());
             if (buildMode) window.draw(buildSprite);
             window.draw(shopPanel); window.draw(cannonIcon); window.draw(archerIcon); window.draw(wizardIcon);
 
             int hp = level1.castle.get_health();
             castleHpText.setString(std::to_string(hp) + " HP");
             auto bounds = castleHpText.getLocalBounds();
-            castleHpText.setOrigin(bounds.left + bounds.width, bounds.top + bounds.height);
-            castleHpText.setPosition(window.getSize().x - 5.f, window.getSize().y - 5.f);
+            castleHpText.setOrigin(bounds.left + bounds.width / 2.f, bounds.top + bounds.height / 2.f);
+            sf::RectangleShape bar = level1.castle.get_health_bar();
+            castleHpText.setPosition(bar.getPosition().x,
+                                     bar.getPosition().y - bar.getSize().y / 2.f - 5.f);
             window.draw(castleHpText);
         }
         else if (state == GameState::Defeat) {


### PR DESCRIPTION
## Summary
- add health bar to `Castle` and track max HP
- update castle health bar on damage
- display castle's health bar in main game loop
- show castle HP text centered above the bar

## Testing
- `cmake -S . -B build` *(fails: could not find SFML)*

------
https://chatgpt.com/codex/tasks/task_e_6858bef45598832eb59f8a4041a5594b